### PR TITLE
Add: missing specs for customer, invoice items, and invoices

### DIFF
--- a/lib/invoice_item.rb
+++ b/lib/invoice_item.rb
@@ -13,7 +13,7 @@ class InvoiceItem
     @id = data[0].to_i
     @item_id = data[1].to_i
     @invoice_id = data[2].to_i
-    @quantity = data[3]
+    @quantity = data[3].to_i
     @unit_price = data[4].to_d / 100
     @created_at = Time.parse(data[5])
     @updated_at = Time.parse(data[6])

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe do
                                    })
   end
 
+  it 'exists' do
+    results = @engine.customers.all.first
+    expect(results).to be_an_instance_of(Customer)
+  end
+
+  it 'has attributes' do
+    item_1 = @engine.customers.all.first
+    expect(item_1.id).to eq(1)
+    expect(item_1.last_name).to eq("Ondricka")
+    item_1 = @engine.customers.all.last
+    expect(item_1.id).to eq(1000)
+    expect(item_1.first_name).to eq("Shawn")
+    item_1 = @engine.customers.find_by_id(1001)
+    expect(item_1).to eq(nil)
+  end
 end

--- a/spec/invoice_item_spec.rb
+++ b/spec/invoice_item_spec.rb
@@ -1,0 +1,35 @@
+require 'csv'
+require 'simplecov'
+require './lib/sales_engine'
+require './lib/invoice_item_repo'
+require './lib/invoice_item'
+SimpleCov.start
+
+RSpec.describe do
+  before(:each) do
+    @engine = SalesEngine.from_csv({
+                                     items: './data/items.csv',
+                                     merchants: './data/merchants.csv',
+                                     invoices: "./data/invoices.csv",
+                                     invoice_items: './data/invoice_items.csv',
+                                     customers: './data/customers.csv',
+                                     transactions: './data/transactions.csv'
+                                   })
+  end
+
+  it 'exists' do
+    results = @engine.invoice_items.all.first
+    expect(results).to be_an_instance_of(InvoiceItem)
+  end
+
+  it 'has attributes' do
+    item_1 = @engine.invoice_items.all.first
+    expect(item_1.id).to eq(1)
+    expect(item_1.quantity).to eq(5)
+    item_1 = @engine.invoice_items.all.last
+    expect(item_1.id).to eq(21830)
+    expect(item_1.invoice_id).to eq(4985)
+    item_1 = @engine.invoice_items.find_by_id(21831)
+    expect(item_1).to eq(nil)
+  end
+end

--- a/spec/invoices_spec.rb
+++ b/spec/invoices_spec.rb
@@ -1,0 +1,35 @@
+require 'csv'
+require 'simplecov'
+require './lib/sales_engine'
+require './lib/invoices'
+require './lib/invoice_repo'
+SimpleCov.start
+
+RSpec.describe do
+  before(:each) do
+    @engine = SalesEngine.from_csv({
+                                     items: './data/items.csv',
+                                     merchants: './data/merchants.csv',
+                                     invoices: "./data/invoices.csv",
+                                     invoice_items: './data/invoice_items.csv',
+                                     customers: './data/customers.csv',
+                                     transactions: './data/transactions.csv'
+                                   })
+  end
+
+  it 'exists' do
+    results = @engine.invoices.all.first
+    expect(results).to be_an_instance_of(Invoice)
+  end
+
+  it 'has attributes' do
+    item_1 = @engine.invoices.all.first
+    expect(item_1.id).to eq(1)
+    expect(item_1.status).to eq(:pending)
+    item_1 = @engine.invoices.all.last
+    expect(item_1.id).to eq(4985)
+    expect(item_1.customer_id).to eq(999)
+    item_1 = @engine.invoices.find_by_id(4986)
+    expect(item_1).to eq(nil)
+  end
+end


### PR DESCRIPTION
Added spec for customer, invoice item, and invoice attributes.

Should get our coverage up to 99% at least

Hopefully this steak keeps hound off my back...

![](https://c.tenor.com/Gdcwou0OXlEAAAAd/uncle-rico-small-napoleon-dynamite.gif)

 